### PR TITLE
Fix newline handling for Windows logs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1048,8 +1048,8 @@
                 return `<a href="${escapeHtml(friendlyUrl)}" target="_blank" rel="noopener noreferrer">${escapeHtml(url)}</a>`;
             });
 
-            // Convert newlines to <br> tags for display in HTML
-            return linkifiedText.replace(/\n/g, '<br>');
+            // Convert CRLF or LF newlines to <br> tags for display in HTML
+            return linkifiedText.replace(/\r?\n/g, '<br>');
         }
 
         /**


### PR DESCRIPTION
## Summary
- correctly convert CRLF newlines when rendering messages

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684091d426f0832c843bbe92670ad9d9